### PR TITLE
fix(storybook): specified the files from `site` and ignore the `storybook-static`

### DIFF
--- a/packages/ui/.gitignore
+++ b/packages/ui/.gitignore
@@ -22,3 +22,4 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+storybook-static

--- a/packages/ui/.storybook/main.js
+++ b/packages/ui/.storybook/main.js
@@ -8,7 +8,14 @@ module.exports = {
   staticDirs: [
     // make `site` as public folder for storybook
     // used in `preview-head.html`
-    "../../site",
+    {
+      from: "../../site/public",
+      to: "/public",
+    },
+    {
+      from: "../../site/src/index.css",
+      to: "/src/index.css",
+    },
   ],
   framework: "@storybook/react",
   // https://github.com/storybookjs/storybook/issues/6188#issuecomment-822924831

--- a/packages/ui/.storybook/main.js
+++ b/packages/ui/.storybook/main.js
@@ -16,6 +16,15 @@ module.exports = {
       from: "../../site/src/index.css",
       to: "/src/index.css",
     },
+    // used in 'Preview/MicromarkMd'
+    {
+      from: "../../site/public/prism.js",
+      to: "/prism.js",
+    },
+    {
+      from: "../../site/public/prism.css",
+      to: "/prism.css",
+    },
   ],
   framework: "@storybook/react",
   // https://github.com/storybookjs/storybook/issues/6188#issuecomment-822924831


### PR DESCRIPTION
should ignore the `pages` files and etc. and ignore the `storybook-static`

![image](https://user-images.githubusercontent.com/19513289/163773494-3354ed43-4992-4b8f-8f49-65113984f050.png)
