### PR TITLE
revert(ui): editor-remove-css

### DIFF
--- a/packages/site/src/index.js
+++ b/packages/site/src/index.js
@@ -6,6 +6,7 @@ import App from "./App";
 import store from "./store";
 import "./index.css";
 import "semantic-ui-css/semantic.min.css";
+import "react-mde/lib/styles/css/react-mde-all.css";
 
 ReactDOM.render(
   <Provider store={store}>

--- a/packages/ui/.storybook/preview.js
+++ b/packages/ui/.storybook/preview.js
@@ -1,4 +1,5 @@
 import "semantic-ui-css/semantic.min.css";
+import "react-mde/lib/styles/css/react-mde-all.css";
 
 export const parameters = {
   actions: { argTypesRegex: "^on[A-Z].*" },

--- a/packages/ui/lib/Editor/MarkdownEditor.js
+++ b/packages/ui/lib/Editor/MarkdownEditor.js
@@ -1,7 +1,6 @@
 import React, { useEffect } from "react";
 import styled, { css } from "styled-components";
 import ReactMde from "react-mde";
-import "react-mde/lib/styles/css/react-mde-all.css";
 import { useRef } from "react";
 
 import HeaderIcon from "../imgs/icons/markdown/header.svg";

--- a/packages/ui/lib/Editor/MarkdownEditor.js
+++ b/packages/ui/lib/Editor/MarkdownEditor.js
@@ -49,11 +49,11 @@ const Wrapper = styled.div`
     border-right: none;
     textarea {
       padding: 12px 16px;
-      border-bottom: 1px solid #e2e8f0 !important;
+      border-bottom: 1px solid #e2e8f0;
       :hover,
       :focus,
       :active {
-        border-color: #b7c0cc !important;
+        border-color: #b7c0cc;
       }
       ${p_14_normal};
       outline: none;

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -41,6 +41,7 @@
     "dayjs": "^1.10.8",
     "micromark": "^3.0.10",
     "micromark-extension-gfm": "^2.0.1",
+    "react-mde": "^11.5.0",
     "react-router-dom": "^6.3.0",
     "sanitize-html": "^2.7.0",
     "styled-components": "4.3.2"

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -41,7 +41,6 @@
     "dayjs": "^1.10.8",
     "micromark": "^3.0.10",
     "micromark-extension-gfm": "^2.0.1",
-    "react-mde": "^11.5.0",
     "react-router-dom": "^6.3.0",
     "sanitize-html": "^2.7.0",
     "styled-components": "4.3.2"

--- a/packages/ui/src/stories/RichEditor.stories.js
+++ b/packages/ui/src/stories/RichEditor.stories.js
@@ -4,6 +4,14 @@ import RichEditor from "../../lib/RichEdit";
 export default {
   name: "RichEditor",
   component: RichEditor,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "requires import 'react-mde/lib/styles/css/react-mde-all.css'",
+      },
+    },
+  },
 };
 
 const markdown = `


### PR DESCRIPTION
import `react-mde/lib/styles/css/react-mde-all.css` by yourself!

reasons:

- nextjs did not allow.