### PR TITLE
feat!(ui): rich editor button props v0.0.51

### DIFF
--- a/packages/ui/lib/RichEdit/index.js
+++ b/packages/ui/lib/RichEdit/index.js
@@ -43,6 +43,8 @@ function RichEdit(
     showButtons = true,
     showOkButton = true,
     showPreviewButton = true,
+    okButtonProps = {},
+    previewButtonProps = {},
     submitting = false,
     disabled = false,
     submitButtonName = "Post",
@@ -71,6 +73,7 @@ function RichEdit(
         <ButtonsWrapper>
           {showPreviewButton && (
             <Button
+              {...previewButtonProps}
               className="button-preview"
               onClick={() => setPreview(!preview)}
             >
@@ -80,6 +83,7 @@ function RichEdit(
           {showOkButton && (
             <Button
               className="button-submit"
+              {...okButtonProps}
               primary
               isLoading={submitting}
               disabled={disabled}

--- a/packages/ui/lib/RichEdit/index.js
+++ b/packages/ui/lib/RichEdit/index.js
@@ -41,13 +41,15 @@ function RichEdit(
     setContent,
     onSubmit = () => {},
     showButtons = true,
-    showOkButton = true,
+    showSubmitButton = true,
     showPreviewButton = true,
-    okButtonProps = {},
+    submitButtonProps = {},
     previewButtonProps = {},
+    // @deprecated use `submitButtonText` instead
+    submitButtonName = "Post",
+    submitButtonText = submitButtonName,
     submitting = false,
     disabled = false,
-    submitButtonName = "Post",
     errorMsg = "",
     loadSuggestions,
   },
@@ -80,10 +82,10 @@ function RichEdit(
               {preview ? "Edit" : "Preview"}
             </Button>
           )}
-          {showOkButton && (
+          {showSubmitButton && (
             <Button
               className="button-submit"
-              {...okButtonProps}
+              {...submitButtonProps}
               primary
               isLoading={submitting}
               disabled={disabled}
@@ -92,7 +94,7 @@ function RichEdit(
                 onSubmit();
               }}
             >
-              {submitButtonName}
+              {submitButtonText || submitButtonName}
             </Button>
           )}
         </ButtonsWrapper>

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osn/common-ui",
-  "version": "0.0.50",
+  "version": "0.0.51",
   "main": "es/index.js",
   "module": "es/index.js",
   "exports": {

--- a/packages/ui/src/stories/RichEditor.stories.js
+++ b/packages/ui/src/stories/RichEditor.stories.js
@@ -125,7 +125,7 @@ export const hidePreviewButton = () => {
 };
 
 export const previewButtonBlock = () => {
-  const [content, setContent] = useState("hide preview button");
+  const [content, setContent] = useState("preview button block");
   return (
     <RichEditor
       content={content}

--- a/packages/ui/src/stories/RichEditor.stories.js
+++ b/packages/ui/src/stories/RichEditor.stories.js
@@ -124,6 +124,20 @@ export const hidePreviewButton = () => {
   );
 };
 
+export const previewButtonBlock = () => {
+  const [content, setContent] = useState("hide preview button");
+  return (
+    <RichEditor
+      content={content}
+      previewButtonProps={{
+        block: true,
+      }}
+      showOkButton={false}
+      setContent={setContent}
+    />
+  );
+};
+
 export const loadSuggestions = () => {
   const [content, setContent] = useState(
     "type `@` to get suggestions here 👇\n\n"

--- a/packages/ui/src/stories/RichEditor.stories.js
+++ b/packages/ui/src/stories/RichEditor.stories.js
@@ -58,13 +58,13 @@ export const disabled = () => {
   return <RichEditor disabled content={content} setContent={setContent} />;
 };
 
-export const submitButtonName = () => {
+export const submitButtonText = () => {
   const [content, setContent] = useState(
     "change the submit button name to `Submit`"
   );
   return (
     <RichEditor
-      submitButtonName="Submit"
+      submitButtonText="Submit"
       content={content}
       setContent={setContent}
     />
@@ -102,12 +102,12 @@ export const hideButtons = () => {
   );
 };
 
-export const hideOkButton = () => {
-  const [content, setContent] = useState("hide ok button");
+export const hideSubmitButton = () => {
+  const [content, setContent] = useState("hide submit button");
   return (
     <RichEditor
       content={content}
-      showOkButton={false}
+      showSubmitButton={false}
       setContent={setContent}
     />
   );
@@ -132,7 +132,7 @@ export const previewButtonBlock = () => {
       previewButtonProps={{
         block: true,
       }}
-      showOkButton={false}
+      showSubmitButton={false}
       setContent={setContent}
     />
   );


### PR DESCRIPTION
## breaks/news

> reason for semantic and historic

- `showOkButton` -> `showSubmitButton`
- `submitButtonText`, deprecated `submitButtonName`
- `submitButtonProps`
- `previewButtonProps`