### PR TITLE
fix(site): page notification review

### DIFF
--- a/packages/site/src/components/Notification/NotificationItem.js
+++ b/packages/site/src/components/Notification/NotificationItem.js
@@ -167,7 +167,7 @@ function extractReplyContent(content) {
   return text;
 }
 
-export default function NotificationItem({ data }) {
+export default function NotificationItem({ data, onMarkAsRead = () => {} }) {
   const {
     type,
     read: origRead,
@@ -221,7 +221,11 @@ export default function NotificationItem({ data }) {
 
             {
               <StatusWrapper>
-                {!read ? <MarkAsReadButton onClick={markAsRead} /> : <div />}
+                {!read ? (
+                  <MarkAsReadButton onClick={() => onMarkAsRead(data)} />
+                ) : (
+                  <div />
+                )}
               </StatusWrapper>
             }
           </InfoWrapper>

--- a/packages/site/src/components/Notification/NotificationItem.js
+++ b/packages/site/src/components/Notification/NotificationItem.js
@@ -6,10 +6,11 @@ import {
   text_dark_minor,
   primary_turquoise_500,
 } from "@osn/common-ui/lib/styles/colors";
-import { ReactComponent as ReadStatus } from "@osn/common-ui/lib/imgs/icons/check.svg";
+import Check from "@osn/common-ui/lib/imgs/icons/check.svg";
 import { Link } from "react-router-dom";
 import { MOBILE_SIZE } from "@osn/consts";
 import { micromark } from "micromark";
+import { useState } from "react";
 
 const dot = css`
   &::after {
@@ -96,15 +97,55 @@ const Title = styled.p`
 
 const StatusWrapper = styled(Flex)`
   width: 18px;
+  height: 18px;
 
   @media screen and (max-width: ${MOBILE_SIZE}px) {
     display: none;
   }
 `;
-const UnreadStatus = styled.div`
-  width: 8px;
-  height: 8px;
-  background-color: ${primary_turquoise_500};
+const MarkAsReadButton = styled.button`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  width: 100%;
+  height: 100%;
+  padding: 0;
+  border: none;
+  background-color: transparent;
+
+  ${(p) =>
+    !p.read &&
+    css`
+      &::before {
+        content: "";
+        display: block;
+        width: 8px;
+        height: 8px;
+        background-color: ${primary_turquoise_500};
+      }
+
+      &::after {
+        content: "";
+        display: none;
+        width: 100%;
+        height: 100%;
+        background: url(${Check}) no-repeat center;
+      }
+
+      &:hover {
+        &::before {
+          display: none;
+        }
+        &::after {
+          display: block;
+        }
+      }
+    `}
+
+  @media screen and (max-width: ${MOBILE_SIZE}px) {
+    display: none;
+  }
 `;
 
 const TypeMap = {
@@ -129,13 +170,20 @@ function extractReplyContent(content) {
 export default function NotificationItem({ data }) {
   const {
     type,
-    read,
+    read: origRead,
     data: { topic, answer, support, fund },
   } = data;
+
+  const [read, setRead] = useState(origRead);
 
   const isReply = assertType(type, "reply");
   const isSupport = assertType(type, "support");
   const isFund = assertType(type, "fund");
+
+  // TODO: call API
+  function markAsRead() {
+    setRead(true);
+  }
 
   let titlePrefix;
   if (isSupport || isFund) {
@@ -171,9 +219,11 @@ export default function NotificationItem({ data }) {
 
             <Time time={topic.createdAt} />
 
-            <StatusWrapper>
-              <Flex>{read ? <ReadStatus /> : <UnreadStatus />}</Flex>
-            </StatusWrapper>
+            {
+              <StatusWrapper>
+                {!read ? <MarkAsReadButton onClick={markAsRead} /> : <div />}
+              </StatusWrapper>
+            }
           </InfoWrapper>
         </Head>
       }

--- a/packages/site/src/components/Notification/NotificationItem.js
+++ b/packages/site/src/components/Notification/NotificationItem.js
@@ -172,9 +172,7 @@ export default function NotificationItem({ data }) {
             <Time time={topic.createdAt} />
 
             <StatusWrapper>
-              {isReply && (
-                <Flex>{read ? <ReadStatus /> : <UnreadStatus />}</Flex>
-              )}
+              <Flex>{read ? <ReadStatus /> : <UnreadStatus />}</Flex>
             </StatusWrapper>
           </InfoWrapper>
         </Head>

--- a/packages/site/src/components/Notification/NotificationItem.js
+++ b/packages/site/src/components/Notification/NotificationItem.js
@@ -113,7 +113,7 @@ const TypeMap = {
   fund: "funded",
 };
 
-const assertType = (t, expect) => t.includes(expect);
+const assertType = (t = [], expect) => t.includes(expect);
 
 function stripHtml(html = "") {
   return html.replace(/<\/?[^>]+(>|$)/gi, "");
@@ -130,17 +130,20 @@ export default function NotificationItem({ data }) {
   const {
     type,
     read,
-    data: { topic, answer, support },
+    data: { topic, answer, support, fund },
   } = data;
 
   const isReply = assertType(type, "reply");
   const isSupport = assertType(type, "support");
+  const isFund = assertType(type, "fund");
 
   let titlePrefix;
-  if (isSupport) {
+  if (isSupport || isFund) {
+    const { bounty } = { ...support, ...fund };
+
     titlePrefix = (
       <Amount>
-        {support?.bounty?.value} {support?.bounty?.symbol}
+        {bounty?.value} {bounty?.symbol}
       </Amount>
     );
   }

--- a/packages/site/src/components/Notification/NotificationItem.js
+++ b/packages/site/src/components/Notification/NotificationItem.js
@@ -180,8 +180,8 @@ export default function NotificationItem({ data, onMarkAsRead = () => {} }) {
   const isSupport = assertType(type, "support");
   const isFund = assertType(type, "fund");
 
-  // TODO: call API
-  function markAsRead() {
+  function handleMarkAsRead(data) {
+    onMarkAsRead(data);
     setRead(true);
   }
 
@@ -222,7 +222,7 @@ export default function NotificationItem({ data, onMarkAsRead = () => {} }) {
             {
               <StatusWrapper>
                 {!read ? (
-                  <MarkAsReadButton onClick={() => onMarkAsRead(data)} />
+                  <MarkAsReadButton onClick={() => handleMarkAsRead(data)} />
                 ) : (
                   <div />
                 )}

--- a/packages/site/src/components/Notification/NotificationItem.js
+++ b/packages/site/src/components/Notification/NotificationItem.js
@@ -5,8 +5,9 @@ import { Time, Card, Flex, FlexBetween } from "@osn/common-ui";
 import {
   text_dark_minor,
   primary_turquoise_500,
+  text_dark_accessory,
 } from "@osn/common-ui/lib/styles/colors";
-import Check from "@osn/common-ui/lib/imgs/icons/check.svg";
+import { ReactComponent as CheckIcon } from "@osn/common-ui/lib/imgs/icons/check.svg";
 import { Link } from "react-router-dom";
 import { MOBILE_SIZE } from "@osn/consts";
 import { micromark } from "micromark";
@@ -16,6 +17,20 @@ const dot = css`
   &::after {
     content: "·";
     margin: 0 8px;
+  }
+`;
+
+const NotificationItemWrapper = styled.div`
+  &:hover {
+    .unread-dot {
+      display: none;
+    }
+    .check-icon {
+      display: block;
+      path {
+        fill: ${text_dark_accessory};
+      }
+    }
   }
 `;
 const Head = styled(Flex)`
@@ -114,38 +129,28 @@ const MarkAsReadButton = styled.button`
   border: none;
   background-color: transparent;
 
-  ${(p) =>
-    !p.read &&
-    css`
-      &::before {
-        content: "";
-        display: block;
-        width: 8px;
-        height: 8px;
-        background-color: ${primary_turquoise_500};
-      }
-
-      &::after {
-        content: "";
-        display: none;
-        width: 100%;
-        height: 100%;
-        background: url(${Check}) no-repeat center;
-      }
-
-      &:hover {
-        &::before {
-          display: none;
-        }
-        &::after {
-          display: block;
-        }
-      }
-    `}
-
-  @media screen and (max-width: ${MOBILE_SIZE}px) {
+  .check-icon {
     display: none;
   }
+
+  &:hover {
+    .unread-dot {
+      display: none;
+    }
+
+    .check-icon {
+      display: block;
+
+      path {
+        fill: ${text_dark_minor};
+      }
+    }
+  }
+`;
+const UnreadDot = styled.div`
+  width: 8px;
+  height: 8px;
+  background-color: ${primary_turquoise_500};
 `;
 
 const TypeMap = {
@@ -197,44 +202,47 @@ export default function NotificationItem({ data, onMarkAsRead = () => {} }) {
   }
 
   return (
-    <Card
-      size="small"
-      head={
-        <Head>
-          <TitleWrapper>
-            <Type>{TypeMap[type] || type}</Type>
-            <Title>
-              {titlePrefix}
-              <Link to={`/topic/${topic.cid}`}>{topic.title}</Link>
-            </Title>
-          </TitleWrapper>
+    <NotificationItemWrapper>
+      <Card
+        size="small"
+        head={
+          <Head>
+            <TitleWrapper>
+              <Type>{TypeMap[type] || type}</Type>
+              <Title>
+                {titlePrefix}
+                <Link to={`/topic/${topic.cid}`}>{topic.title}</Link>
+              </Title>
+            </TitleWrapper>
 
-          <InfoWrapper>
-            <NetworkUser
-              address={topic.signer}
-              network={topic.network}
-              iconSize={16}
-              tooltipPosition="down"
-            />
+            <InfoWrapper>
+              <NetworkUser
+                address={topic.signer}
+                network={topic.network}
+                iconSize={16}
+                tooltipPosition="down"
+              />
 
-            <Time time={topic.createdAt} />
+              <Time time={topic.createdAt} />
 
-            {
               <StatusWrapper>
                 {!read ? (
-                  <MarkAsReadButton onClick={() => handleMarkAsRead(data)} />
+                  <MarkAsReadButton onClick={() => handleMarkAsRead(data)}>
+                    <UnreadDot className="unread-dot" />
+                    <CheckIcon className="check-icon" />
+                  </MarkAsReadButton>
                 ) : (
                   <div />
                 )}
               </StatusWrapper>
-            }
-          </InfoWrapper>
-        </Head>
-      }
-    >
-      {isReply && (
-        <ReplyContent>{extractReplyContent(answer.content)}</ReplyContent>
-      )}
-    </Card>
+            </InfoWrapper>
+          </Head>
+        }
+      >
+        {isReply && (
+          <ReplyContent>{extractReplyContent(answer.content)}</ReplyContent>
+        )}
+      </Card>
+    </NotificationItemWrapper>
   );
 }

--- a/packages/site/src/components/Notification/NotificationItem.js
+++ b/packages/site/src/components/Notification/NotificationItem.js
@@ -167,7 +167,7 @@ export default function NotificationItem({ data }) {
               network={topic.network}
               iconSize={16}
               tooltipPosition="down"
-            ></NetworkUser>
+            />
 
             <Time time={topic.createdAt} />
 

--- a/packages/site/src/components/Notification/NotificationItem.js
+++ b/packages/site/src/components/Notification/NotificationItem.js
@@ -109,7 +109,8 @@ const UnreadStatus = styled.div`
 
 const TypeMap = {
   topicResolved: "resolved",
-  support: "supported",
+  support: "promised",
+  fund: "funded",
 };
 
 const assertType = (t, expect) => t.includes(expect);

--- a/packages/site/src/pages/Notifications.js
+++ b/packages/site/src/pages/Notifications.js
@@ -1,8 +1,8 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import styled from "styled-components";
 
 import { NoData, Pagination, Container, List, Flex } from "@osn/common-ui";
-import { useDispatch, useSelector } from "react-redux";
+import { useSelector } from "react-redux";
 import { clearUnread } from "store/reducers/notificationSlice";
 import { accountSelector } from "store/reducers/accountSlice";
 import ListLoader from "@osn/common-ui/lib/Skeleton/ListLoader";
@@ -37,7 +37,6 @@ const ReadAllButton = styled(Flex)`
 `;
 
 export default function Notifications() {
-  const dispatch = useDispatch();
   const pageSize = 10;
   const [page, setPage] = useState(1);
   const account = useSelector(accountSelector);
@@ -48,12 +47,6 @@ export default function Notifications() {
     tab,
     setPage
   );
-
-  useEffect(() => {
-    if (account?.address && account?.network) {
-      dispatch(clearUnread(account.network, account.address));
-    }
-  }, [dispatch, account?.network, account?.address]);
 
   return (
     <Wrapper>

--- a/packages/site/src/pages/Notifications.js
+++ b/packages/site/src/pages/Notifications.js
@@ -81,10 +81,10 @@ export default function Notifications() {
               <List.Item>
                 <NotificationItem
                   data={item}
-                  onMarkAsRead={() =>
+                  onMarkAsRead={(data) =>
                     dispatch(
                       clearUnread(account.network, account.address, {
-                        items: [item._id],
+                        items: [data._id],
                       })
                     )
                   }

--- a/packages/site/src/pages/Notifications.js
+++ b/packages/site/src/pages/Notifications.js
@@ -84,7 +84,7 @@ export default function Notifications() {
                   onMarkAsRead={() =>
                     dispatch(
                       clearUnread(account.network, account.address, {
-                        items: [item],
+                        items: [item._id],
                       })
                     )
                   }

--- a/packages/site/src/pages/Notifications.js
+++ b/packages/site/src/pages/Notifications.js
@@ -42,7 +42,7 @@ export default function Notifications() {
   const [page, setPage] = useState(1);
   const account = useSelector(accountSelector);
   const [tab, setTab] = useState("notifications");
-  const [isLoading, notifications] = useNotifications(
+  const [isLoading, notifications, setNotifications] = useNotifications(
     page,
     account,
     tab,
@@ -59,9 +59,11 @@ export default function Notifications() {
           notifications?.items?.length > 0 && (
             <ReadAllButton
               role="button"
-              onClick={() =>
-                dispatch(clearUnread(account.network, account.address))
-              }
+              onClick={() => {
+                dispatch(clearUnread(account.network, account.address));
+                // do refresh
+                setNotifications({ total: null });
+              }}
             >
               <CheckUnderline style={{ marginRight: 11 }} />
               Mark all as read

--- a/packages/site/src/pages/Notifications.js
+++ b/packages/site/src/pages/Notifications.js
@@ -2,7 +2,7 @@ import { useState } from "react";
 import styled from "styled-components";
 
 import { NoData, Pagination, Container, List, Flex } from "@osn/common-ui";
-import { useSelector } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import { clearUnread } from "store/reducers/notificationSlice";
 import { accountSelector } from "store/reducers/accountSlice";
 import ListLoader from "@osn/common-ui/lib/Skeleton/ListLoader";
@@ -37,6 +37,7 @@ const ReadAllButton = styled(Flex)`
 `;
 
 export default function Notifications() {
+  const dispatch = useDispatch();
   const pageSize = 10;
   const [page, setPage] = useState(1);
   const account = useSelector(accountSelector);
@@ -58,7 +59,9 @@ export default function Notifications() {
           notifications?.items?.length > 0 && (
             <ReadAllButton
               role="button"
-              onClick={clearUnread(account.network, account.address)}
+              onClick={() =>
+                dispatch(clearUnread(account.network, account.address))
+              }
             >
               <CheckUnderline style={{ marginRight: 11 }} />
               Mark all as read
@@ -76,7 +79,16 @@ export default function Notifications() {
             data={notifications?.items}
             itemRender={(item) => (
               <List.Item>
-                <NotificationItem data={item} />
+                <NotificationItem
+                  data={item}
+                  onMarkAsRead={() =>
+                    dispatch(
+                      clearUnread(account.network, account.address, {
+                        items: [item],
+                      })
+                    )
+                  }
+                />
               </List.Item>
             )}
           />

--- a/packages/site/src/pages/Notifications.js
+++ b/packages/site/src/pages/Notifications.js
@@ -51,9 +51,7 @@ export default function Notifications() {
   return (
     <Wrapper>
       <NotificationTabs
-        items={[
-          { value: "notifications", suffix: notifications?.items?.length },
-        ]}
+        items={[{ value: "notifications", suffix: notifications?.total }]}
         value={tab}
         setValue={setTab}
         extra={

--- a/packages/site/src/pages/Notifications.js
+++ b/packages/site/src/pages/Notifications.js
@@ -78,7 +78,7 @@ export default function Notifications() {
             data={notifications?.items}
             itemRender={(item) => (
               <List.Item>
-                <NotificationItem data={item}></NotificationItem>
+                <NotificationItem data={item} />
               </List.Item>
             )}
           />

--- a/packages/site/src/store/reducers/notificationSlice.js
+++ b/packages/site/src/store/reducers/notificationSlice.js
@@ -27,9 +27,12 @@ export const fetchUnread = (network, address) => async (dispatch) => {
     });
 };
 
-export const clearUnread = (network, address) => async (dispatch) => {
+export const clearUnread = (network, address, body) => async (dispatch) => {
   serverApi
-    .post(`/network/${network}/address/${address}/notifications/clearunread`)
+    .post(
+      `/network/${network}/address/${address}/notifications/clearunread`,
+      body
+    )
     .then(({ result }) => {
       if (result) {
         dispatch(setUnread(0));

--- a/packages/site/src/utils/hooks.js
+++ b/packages/site/src/utils/hooks.js
@@ -73,7 +73,8 @@ export function useNotifications(page, account, tab, setPage) {
         });
     }
   }, [account?.network, account?.address, page, tab, notifications.total]);
-  return [isLoading, notifications];
+
+  return [isLoading, notifications, setNotifications];
 }
 
 export const useBalance = (account, api) => {

--- a/packages/ui/lib/Card/Card.js
+++ b/packages/ui/lib/Card/Card.js
@@ -69,12 +69,7 @@ function Card(props) {
   );
 
   return (
-    <CardWrapper
-      {...restProps}
-      size={size}
-      shadow={shadow}
-      className="osn-card"
-    >
+    <CardWrapper {...restProps} size={size} shadow={shadow} className="card">
       {head}
       {head && children && <Divider />}
       {children}

--- a/packages/ui/lib/Card/Card.js
+++ b/packages/ui/lib/Card/Card.js
@@ -69,7 +69,12 @@ function Card(props) {
   );
 
   return (
-    <CardWrapper {...restProps} size={size} shadow={shadow} className="card">
+    <CardWrapper
+      {...restProps}
+      size={size}
+      shadow={shadow}
+      className="osn-card"
+    >
       {head}
       {head && children && <Divider />}
       {children}


### PR DESCRIPTION
close #526 , close #515 

- [x] don't call `clearUnread` automatically
- [x] type
  - [x] support -> Promised
  - [x] fund -> funded
- [x] type `fund` has amount to show
- [x] show status for all item
- [x] the ✓ status is clickable, mark this one as read