### PR TITLE
feat(ui): markdown preview allowtags

### DIFF
--- a/packages/ui/lib/Preview/index.js
+++ b/packages/ui/lib/Preview/index.js
@@ -1,6 +1,7 @@
 import React from "react";
 import MicromarkMd from "./MicromarkMd";
 import styled, { css } from "styled-components";
+import sanitizeHtml from "sanitize-html";
 
 const PreviewWrapper = styled.div`
   ${(p) =>
@@ -16,7 +17,12 @@ const PreviewWrapper = styled.div`
     `}
 `;
 
-function Preview({ content, bordered = true, allowTags, minHeight }) {
+function Preview({
+  content,
+  bordered = true,
+  allowTags = sanitizeHtml.defaults.allowedTags.concat(["img", "iframe", "br"]),
+  minHeight,
+}) {
   return (
     <PreviewWrapper bordered={bordered} minHeight={minHeight}>
       <MicromarkMd md={content} allowTags={allowTags} />

--- a/packages/ui/lib/Preview/index.js
+++ b/packages/ui/lib/Preview/index.js
@@ -16,10 +16,10 @@ const PreviewWrapper = styled.div`
     `}
 `;
 
-function Preview({ content, bordered = true, minHeight }) {
+function Preview({ content, bordered = true, allowTags, minHeight }) {
   return (
     <PreviewWrapper bordered={bordered} minHeight={minHeight}>
-      <MicromarkMd md={content} />
+      <MicromarkMd md={content} allowTags={allowTags} />
     </PreviewWrapper>
   );
 }

--- a/packages/ui/lib/index.js
+++ b/packages/ui/lib/index.js
@@ -16,6 +16,7 @@ import List from "./List";
 import Time from "./Time";
 import Card from "./Card";
 import Tabs from "./Tabs";
+import MarkdownPreview from "./Preview";
 //styled
 import Button from "./styled/Button";
 import Container from "./styled/Container";
@@ -67,4 +68,5 @@ export {
   List,
   Time,
   Tabs,
+  MarkdownPreview,
 };


### PR DESCRIPTION
don't use sub component directly #442 

export as `MarkdownPreview` , reason: more semantic