### PR TITLE
fix(ui): footer icon gap v0.0.54

### DIFF
--- a/packages/ui/lib/Footer/index.js
+++ b/packages/ui/lib/Footer/index.js
@@ -82,7 +82,7 @@ const Item = styled.div`
   font-size: 16px;
   line-height: 24px;
   color: rgba(255, 255, 255, 0.65);
-  > img {
+  > svg {
     width: 24px;
     height: 24px;
     margin-right: 8px;
@@ -96,11 +96,7 @@ const RightWrapper = styled.div`
   display: flex;
   flex-direction: column;
   align-items: flex-end;
-  > img {
-    width: 68px;
-    height: 48px;
-    margin-bottom: 120px;
-  }
+
   > div {
     text-align: right;
     font-size: 16px;

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osn/common-ui",
-  "version": "0.0.53",
+  "version": "0.0.54",
   "main": "es/index.js",
   "module": "es/index.js",
   "types": "es/index.d.ts",


### PR DESCRIPTION
close #545 

<img width="764" alt="image" src="https://user-images.githubusercontent.com/19513289/168016813-8279a456-2bdb-4532-8775-57f62eeb5a84.png">
