### PR TITLE
fix(ui): v0.0.55, time deps

### DIFF
--- a/packages/ui/lib/Time/index.js
+++ b/packages/ui/lib/Time/index.js
@@ -1,6 +1,6 @@
 import React from "react";
 import styled from "styled-components";
-import { timeDuration } from "@osn/common";
+import { timeDuration } from "./utils";
 
 const Wrapper = styled.div`
   font-size: 14px;

--- a/packages/ui/lib/Time/utils.js
+++ b/packages/ui/lib/Time/utils.js
@@ -1,0 +1,53 @@
+import dayjs from "dayjs";
+import updateLocale from "dayjs/plugin/updateLocale";
+dayjs.extend(updateLocale);
+
+export function timeDuration(time) {
+  if (!time) {
+    return "Unknown time";
+  }
+  dayjs.updateLocale("en", {
+    relativeTime: {
+      future: "in %s",
+      past: "%s ago",
+      s: "secs",
+      ss: "%ds",
+      m: "1min",
+      mm: "%dmin",
+      h: "1h",
+      hh: "%dhrs",
+      d: "1d",
+      dd: "%dd",
+      M: "1mo",
+      MM: "%dmos",
+      y: "1y",
+      yy: "%dy",
+    },
+  });
+  const now = dayjs();
+  if (!now.isAfter(time)) {
+    return dayjs(time).fromNow();
+  }
+  let ss = now.diff(time, "seconds");
+  let ii = now.diff(time, "minutes");
+  let hh = now.diff(time, "hours");
+  let dd = now.diff(time, "days");
+  let mm = now.diff(time, "months");
+  let yy = now.diff(time, "years");
+  if (yy) {
+    return `${yy}y ago`;
+  }
+  if (mm) {
+    return `${mm}mo ago`;
+  }
+  if (dd) {
+    return `${dd}d ago`;
+  }
+  if (hh) {
+    return `${hh}h ago`;
+  }
+  if (ii) {
+    return `${ii}min ago`;
+  }
+  return `${ss}s ago`;
+}

--- a/packages/ui/lib/Time/utils.test.js
+++ b/packages/ui/lib/Time/utils.test.js
@@ -1,0 +1,11 @@
+import { timeDuration } from "./utils";
+
+test("timeDuration", () => {
+  const now = Math.floor(new Date().getTime() / 1000) * 1000;
+  expect(timeDuration(now)).toBe("0s ago");
+  expect(timeDuration(now - 61 * 1000)).toBe("1min 1s ago");
+  expect(timeDuration(now - 3661 * 1000)).toBe("1h 1min ago");
+  expect(timeDuration(now - 90000 * 1000)).toBe("1d 1h ago");
+  expect(timeDuration(now - Math.pow(10, 10))).toBe("3mos ago");
+  expect(timeDuration(now - Math.pow(10, 11))).toBe("3y 2mos ago");
+});

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osn/common-ui",
-  "version": "0.0.54",
+  "version": "0.0.55",
   "main": "es/index.js",
   "module": "es/index.js",
   "types": "es/index.d.ts",


### PR DESCRIPTION
move utils

@osn/common -> @polkadot/xxx -> `window`, meaning: errors in nextjs

### explain

nextjs

```js
import {} from '@osn/common-ui' // osn/common-ui/es/index.js
```

common-ui/es/index.js

```js
import Time from '../Time'

export { Time }
```

Time

```js
import {} from '@osn/common' // osn/common/bundle.js
```

osn/common/bundle.js

```js
import '@polkadot/xxxx' // use `window`, maybe in api, utils, extension-app, wasm-crypto-wasm
```