### PR TITLE
fix(ui): v0.0.60 markdown preview link

### DIFF
--- a/packages/ui/lib/Preview/MicromarkMd.js
+++ b/packages/ui/lib/Preview/MicromarkMd.js
@@ -2,7 +2,7 @@ import React, { useEffect } from "react";
 import styled from "styled-components";
 import { micromark } from "micromark";
 import { gfm, gfmHtml } from "micromark-extension-gfm";
-import { matchMdLink, replaceMentionLinks } from "./utils";
+import { replaceMentionLinks } from "./utils";
 import sanitizeHtml from "sanitize-html";
 import markdownStyle from "../styles/markdown";
 
@@ -12,8 +12,8 @@ const Wrapper = styled.div`
 `;
 
 export default function MicromarkMd({ md = "", allowTags }) {
-  const linkMd = matchMdLink(replaceMentionLinks(md));
-  const displayContent = linkMd.replace(/\n+/g, function (ns) {
+  const mentionedMd = replaceMentionLinks(md);
+  const displayContent = mentionedMd.replace(/\n+/g, function (ns) {
     if (ns.length === 1) return "  " + ns;
     return ns;
   });

--- a/packages/ui/lib/Preview/utils.js
+++ b/packages/ui/lib/Preview/utils.js
@@ -1,10 +1,4 @@
-export function matchMdLink(t) {
-  const expression =
-    /(?!]\()((?:https?|ftp):\/\/[^\s\])]*)(?:[\s\])](?!\()|$)/gi;
-  return t.replace(expression, "[$1]($1) ");
-}
-
 export function replaceMentionLinks(t) {
-  const expression = /\[(@[^\]\[]+)]\((\/network\/\w+\/address\/\w+)\)/g;
+  const expression = /\[(@[^\]\[]+)\]\((\/network\/\w+\/address\/\w+)\)/g;
   return t.replace(expression, "[$1](/#$2) ");
 }

--- a/packages/ui/lib/Preview/utils.test.js
+++ b/packages/ui/lib/Preview/utils.test.js
@@ -1,12 +1,4 @@
-import { matchMdLink, replaceMentionLinks } from "./utils";
-
-test("matchMdLink", () => {
-  expect(
-    matchMdLink(`##HELLO, 
-  https://www.opensquare.io/ is a great website`)
-  ).toBe(`##HELLO, 
-  [https://www.opensquare.io/](https://www.opensquare.io/) is a great website`);
-});
+import { replaceMentionLinks } from "./utils";
 
 test("replaceMentionLinks", () => {
   expect(

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osn/common-ui",
-  "version": "0.0.58",
+  "version": "0.0.59",
   "main": "es/index.js",
   "module": "es/index.js",
   "types": "es/index.d.ts",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osn/common-ui",
-  "version": "0.0.59",
+  "version": "0.0.60",
   "main": "es/index.js",
   "module": "es/index.js",
   "types": "es/index.d.ts",


### PR DESCRIPTION
## breaks

- no need `matchMdLink`, gfm already did it for us.

## reverts

- `replaceMentionLink` regex revert

## preview

### safari

<img width="929" alt="image" src="https://user-images.githubusercontent.com/19513289/168997254-a88d2169-3ef6-48b8-97f5-07c336681d9c.png">
